### PR TITLE
fix: Add --tag next option for prerelease versions in npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,9 @@ jobs:
         run: npm run build
 
       - name: Publish to npm with OIDC
-        run: npm publish --provenance
+        run: |
+          if [[ $GITHUB_REF == refs/tags/*-rc* ]]; then
+            npm publish --provenance --tag next
+          else
+            npm publish --provenance
+          fi


### PR DESCRIPTION
## Summary

- Add conditional logic to use `--tag next` for prerelease versions (rc) in npm publish workflow
- Fixes the error: "You must specify a tag using --tag when publishing a prerelease version"

## Changes

- Modified `.github/workflows/release.yml` to detect rc tags and automatically add `--tag next` option
- Stable releases continue to use the default `latest` tag

## How it works

- RC versions: Published with `npm publish --provenance --tag next`
  - Users can install with: `npm install express-errorhandlers@next`
- Stable versions: Published with `npm publish --provenance`
  - Users can install with: `npm install express-errorhandlers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)